### PR TITLE
Fix

### DIFF
--- a/crm/app/controllers/invoices_controller.rb
+++ b/crm/app/controllers/invoices_controller.rb
@@ -45,10 +45,11 @@ class InvoicesController < ApplicationController
 
   # 帳票出力処理
   def report
+    @invoice = Invoice.find(params[:id])
     report = Thinreports::Report.new layout: "app/reports/layouts/invoices.tlf"
     report.start_new_page
     report.page.values(
-    created_at: @invoice.try("@invoice.created_at"), 
+    created_at: @invoice.try(:created_at),
     company: @invoice.try("@invoice.company.company"), #@companyのcompany
     postnumber: @invoice.try("@invoice.company.postnumber"), #@companyのpostnumber
     address: @invoice.try("@invoice.company.address"), #@companyのaddress

--- a/crm/app/controllers/uploader_controller.rb
+++ b/crm/app/controllers/uploader_controller.rb
@@ -7,10 +7,16 @@ class UploaderController < ApplicationController
 
 
   def download
-      @upload_file = UploadFile.find(params[:id].to_i)
-      filepath = @upload_file.file.current_path
-      stat = File::stat(filepath)
-      send_file(filepath, :filename => @upload_file.file.url.gsub(/.*\//,''), :length => stat.size)
+    @upload_file = UploadFile.find(params[:id].to_i)
+    filepath = @upload_file.file.current_path
+    stat = File::stat(filepath)
+    send_file(filepath, :filename => @upload_file.file.url.gsub(/.*\//,''), :length => stat.size)
+  end
+  def view
+    @upload_file = UploadFile.find(params[:id].to_i)
+    filepath = @upload_file.file.current_path
+    stat = File::stat(filepath)
+    send_file(filepath, :filename => @upload_file.file.url.gsub(/.*\//,''), :length => stat.size, :disposition => 'inline')
   end
   
   def upload_process

--- a/crm/app/views/companies/_index.html.erb
+++ b/crm/app/views/companies/_index.html.erb
@@ -12,8 +12,8 @@
 <% @companies.each do |company| %>
 <tr>
 <td><%= check_box_tag "deletes[#{ company.id }]", company.id %></td>
-<td><%= link_to company.company, company_path(company) %></td>
-<td><%= link_to company.first_name, company_path(company) %></td>
+<td><%= link_to company.company, company_path(company), "data-turbolinks"=>"false" %></td>
+<td><%= link_to company.first_name, company_path(company), "data-turbolinks"=>"false" %></td>
 <td><%= company.tel %></td>
 <td><%= company.e_mail %></td>
 <td><%= link_to '編集', edit_company_path(company), class: 'command'%>

--- a/crm/app/views/invoices/index.html.erb
+++ b/crm/app/views/invoices/index.html.erb
@@ -20,7 +20,7 @@
 			            	method: :delete, 
 			            	class: 'command',
 			            	data: { confirm: '本当に削除しますか？'} %>
-			            ｜<%= link_to 'pdf', report_invoice_path(@invoices, format: 'pdf') %>
+			            ｜<%= link_to 'pdf', report_invoice_path(invoice, format: 'pdf') %>
 			            	</td>
 
       		</tr>

--- a/crm/app/views/uploader/index.html.erb
+++ b/crm/app/views/uploader/index.html.erb
@@ -2,13 +2,14 @@
     <div class="heading"><h2>ドキュメントダウンロード</h2>
             </div>
     
-    <table width="90%">
+    <table width="90%" data-turbolinks="false">
      <tbody>
           <% UploadFile.all.reverse_order.each do |upload| %>
         <tr>
             <th>ファイル名</th>
-            <td><%= link_to upload.name, action: "download", id: upload.id %></td>
-        </tr>     
+            <td><%= link_to upload.name, {action: "view", id: upload.id} %></td>
+            <td><%= link_to "download", {action: "download", id: upload.id} %></td>
+        </tr>
       <% end %>
       </tbody>
     </table> 


### PR DESCRIPTION
1. companies/show下部に御座いますデータ添付のアップロードが遅い点
原因：　turbolinkというjsライブラリの利用方法が間違っている
修正：　企業一覧画面からturbolinkを無効化にする
※

2.uploader/indexより『あいう』データをダウンロードするとしばらくフリーズし、文字化けが発生する点
3. 閲覧画面についてはこのindexの『あいう』をクリックした際に中身を表示されるよう実装したく存じます。
原因：　turbolinkというjsライブラリの利用方法が間違っている
修正：　
    ファイル一覧画面（uploader/index）からturbolinkを無効化にする
    ダウンロードボタンを配置する
    ファイル名をクリックするとファイル内容を表示させ、ダウンロードボタンをクリックするとファイルをダウンロードさせるようにする

4.請求書については、ヘッダー請求書をクリック頂くと、PDFをクリックする点がありますが、そこをクリックしてもinvoice_controller に明記した内容が何も表示されません。これを表示されるように改善したく存じます。
原因：提示したソースコード内に、初期化されない変数（@invoice）が利用される
修正：
    利用する前に、@invoiceを初期化する
＝＝＝＝
上記の修正したソースコードを下記のサイトからでも動作確認できるので、
修正内容のご確認の上、ソースコードのマージをお願いいたします。
    http://devdemo.relipasoft.com:3000/admins/sign_in